### PR TITLE
Fixed utf8 input for xml and added basic .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+# Idea
+*.iml
+.idea

--- a/src/main/java/be/ugent/mmlab/rml/logicalsourcehandler/termmap/AbstractTermMapProcessor.java
+++ b/src/main/java/be/ugent/mmlab/rml/logicalsourcehandler/termmap/AbstractTermMapProcessor.java
@@ -1,23 +1,10 @@
 package be.ugent.mmlab.rml.logicalsourcehandler.termmap;
 
 import be.ugent.mmlab.rml.model.RDFTerm.TermMap;
-import static be.ugent.mmlab.rml.model.RDFTerm.TermMap.TermMapType.CONSTANT_VALUED;
-import static be.ugent.mmlab.rml.model.RDFTerm.TermMap.TermMapType.REFERENCE_VALUED;
-import static be.ugent.mmlab.rml.model.RDFTerm.TermMap.TermMapType.TEMPLATE_VALUED;
 import be.ugent.mmlab.rml.model.RDFTerm.TermType;
-import static be.ugent.mmlab.rml.model.RDFTerm.TermType.BLANK_NODE;
-import static be.ugent.mmlab.rml.model.RDFTerm.TermType.IRI;
-import static be.ugent.mmlab.rml.model.RDFTerm.TermType.LITERAL;
 import be.ugent.mmlab.rml.model.std.StdTemplateMap;
 import be.ugent.mmlab.rml.model.termMap.ReferenceMap;
 import be.ugent.mmlab.rml.vocabularies.QLVocabulary.QLTerm;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.openrdf.model.URI;
 import org.openrdf.model.Value;
 import org.openrdf.model.impl.BNodeImpl;
@@ -25,6 +12,14 @@ import org.openrdf.model.impl.LiteralImpl;
 import org.openrdf.model.impl.URIImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * RML Processor
@@ -49,7 +44,7 @@ public abstract class AbstractTermMapProcessor implements TermMapProcessor{
                 //Get the expression and extract the value
                 ReferenceMap identifier = map.getReferenceMap();
                 values = extractValueFromNode(
-                        node, identifier.getReference().toString().trim());
+                        node, identifier.getReference().trim());
 
                 for (String value : values) {
                     valueList.add(value.trim().replace("\n", " "));
@@ -107,7 +102,8 @@ public abstract class AbstractTermMapProcessor implements TermMapProcessor{
                                         .replaceAll("\\%27", "'")
                                         .replaceAll("\\%28", "(")
                                         .replaceAll("\\%29", ")")
-                                        .replaceAll("\\%7E", "~"));
+                                        .replaceAll("\\%7E", "~"))
+                                        .replaceAll("\\%3A", ":");
                             } else {
                                 temp = temp.replaceAll("\\{" + expression + "\\}", 
                                         Matcher.quoteReplacement(replacement));
@@ -116,7 +112,7 @@ public abstract class AbstractTermMapProcessor implements TermMapProcessor{
                         } catch (UnsupportedEncodingException ex) {
                             log.error("UnsupportedEncodingException " + ex);
                         }
-                        values.set(i, temp.toString());
+                        values.set(i, temp);
 
                      }
                 }
@@ -124,8 +120,7 @@ public abstract class AbstractTermMapProcessor implements TermMapProcessor{
                 //Check if there are any placeholders left in the templates and remove uris that are not
                 List<String> validValues = new ArrayList<>();
                 for (String uri : values){
-                    StdTemplateMap templateMap = new StdTemplateMap(uri);
-                    if (templateMap.extractVariablesFromStringTemplate(uri).isEmpty()){
+                    if (StdTemplateMap.extractVariablesFromStringTemplate(uri).isEmpty()){
                         validValues.add(uri);
                     }
                 }

--- a/src/main/java/be/ugent/mmlab/rml/logicalsourcehandler/termmap/concrete/JSONPathTermMapProcessor.java
+++ b/src/main/java/be/ugent/mmlab/rml/logicalsourcehandler/termmap/concrete/JSONPathTermMapProcessor.java
@@ -2,12 +2,13 @@ package be.ugent.mmlab.rml.logicalsourcehandler.termmap.concrete;
 
 import be.ugent.mmlab.rml.logicalsourcehandler.termmap.AbstractTermMapProcessor;
 import com.jayway.jsonpath.JsonPath;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import net.minidev.json.JSONArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * RML Processor
@@ -34,7 +35,13 @@ public class JSONPathTermMapProcessor extends AbstractTermMapProcessor {
                 JSONArray arr = (JSONArray) val;
                 return Arrays.asList(arr.toArray(new String[0]));
             }
-            list.add((String) val.toString());
+
+            // handle null values
+            if (val == null) {
+                val = "";
+            }
+
+            list.add(val.toString());
             return list;
         } catch (com.jayway.jsonpath.InvalidPathException ex) {
             log.debug("InvalidPathException " + ex + "for " + expression);

--- a/src/main/java/be/ugent/mmlab/rml/logicalsourcehandler/termmap/concrete/XPathTermMapProcessor.java
+++ b/src/main/java/be/ugent/mmlab/rml/logicalsourcehandler/termmap/concrete/XPathTermMapProcessor.java
@@ -2,10 +2,6 @@ package be.ugent.mmlab.rml.logicalsourcehandler.termmap.concrete;
 
 import be.ugent.mmlab.rml.logicalsourcehandler.termmap.AbstractTermMapProcessor;
 import be.ugent.mmlab.rml.xml.XOMBuilder;
-import java.io.StringBufferInputStream;
-import java.util.ArrayList;
-import java.util.List;
-import javax.xml.xpath.XPathException;
 import jlibs.xml.DefaultNamespaceContext;
 import jlibs.xml.sax.dog.NodeItem;
 import jlibs.xml.sax.dog.XMLDog;
@@ -18,6 +14,11 @@ import org.jaxen.saxpath.SAXPathException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.InputSource;
+
+import javax.xml.xpath.XPathException;
+import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * RML Processor
@@ -56,9 +57,9 @@ public class XPathTermMapProcessor extends AbstractTermMapProcessor {
         } catch (SAXPathException ex) {
             log.error("SAXPathException " + ex);
         }
-        StringBufferInputStream input = 
-                new StringBufferInputStream(node.toXML().toString());
-        
+        ByteArrayInputStream input =
+                new ByteArrayInputStream(node.toXML().getBytes());
+
         InputSource source = new InputSource(input);
         Event event = dog.createEvent();
         event.setXMLBuilder(new XOMBuilder());
@@ -69,7 +70,7 @@ public class XPathTermMapProcessor extends AbstractTermMapProcessor {
                     Expression expression, NodeItem nodeItem) {
                 Node node = (Node) nodeItem.xml;    
                 //if(nodeItem instanceOf Attribute)
-                list.add(node.getValue().toString());
+                list.add(node.getValue());
             }
 
             @Override

--- a/src/main/java/be/ugent/mmlab/rml/logicalsourcehandler/termmap/concrete/XPathTermMapProcessor.java
+++ b/src/main/java/be/ugent/mmlab/rml/logicalsourcehandler/termmap/concrete/XPathTermMapProcessor.java
@@ -17,6 +17,7 @@ import org.xml.sax.InputSource;
 
 import javax.xml.xpath.XPathException;
 import java.io.ByteArrayInputStream;
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -58,7 +59,7 @@ public class XPathTermMapProcessor extends AbstractTermMapProcessor {
             log.error("SAXPathException " + ex);
         }
         ByteArrayInputStream input =
-                new ByteArrayInputStream(node.toXML().getBytes());
+                new ByteArrayInputStream(node.toXML().getBytes(Charset.forName("UTF-8")));
 
         InputSource source = new InputSource(input);
         Event event = dog.createEvent();


### PR DESCRIPTION
This one should fix UTF8 XML input be successfully processed by RML.
Besides that, I added handling of Json null values and colons are now allowed in fragments.